### PR TITLE
Pass `--no-as-needed` when linking main binary.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -64,6 +64,7 @@ $(BIN): src/git_info.hpp src/main.o src/config_parser.o
 	src/main.o \
 	src/config_parser.o \
 	$(CXXFLAGS) \
+	-Wl,--no-as-needed \
 	$(shell pkg-config --libs gtkmm-4.0 gtk4-layer-shell-0)
 
 $(LIB): $(OBJS)


### PR DESCRIPTION
This option forces linker to link with dynamic library even if linker thinks that it's not used. This is needed to make sure that main binary loads gtk4-layer-shell.so **before** wayland-client.so.

<details><summary>`ldd syshud` with this patch</summary>
<p>

```
$ ldd syshud 
	linux-vdso.so.1 (0x00007faa646bc000)
	libgtkmm-4.0.so.0 => /lib/x86_64-linux-gnu/libgtkmm-4.0.so.0 (0x00007faa64000000)
	libpangomm-2.48.so.1 => /lib/x86_64-linux-gnu/libpangomm-2.48.so.1 (0x00007faa6465b000)
	libgiomm-2.68.so.1 => /lib/x86_64-linux-gnu/libgiomm-2.68.so.1 (0x00007faa63c00000)
	libglibmm-2.68.so.1 => /lib/x86_64-linux-gnu/libglibmm-2.68.so.1 (0x00007faa645d5000)
	libcairomm-1.16.so.1 => /lib/x86_64-linux-gnu/libcairomm-1.16.so.1 (0x00007faa645a5000)
	libsigc-3.0.so.0 => /lib/x86_64-linux-gnu/libsigc-3.0.so.0 (0x00007faa64597000)
	libgtk-4.so.1 => /lib/x86_64-linux-gnu/libgtk-4.so.1 (0x00007faa63000000)
	libpangocairo-1.0.so.0 => /lib/x86_64-linux-gnu/libpangocairo-1.0.so.0 (0x00007faa64586000)
	libpango-1.0.so.0 => /lib/x86_64-linux-gnu/libpango-1.0.so.0 (0x00007faa64517000)
	libharfbuzz.so.0 => /lib/x86_64-linux-gnu/libharfbuzz.so.0 (0x00007faa63ec2000)
	libgdk_pixbuf-2.0.so.0 => /lib/x86_64-linux-gnu/libgdk_pixbuf-2.0.so.0 (0x00007faa63e94000)
	libcairo-gobject.so.2 => /lib/x86_64-linux-gnu/libcairo-gobject.so.2 (0x00007faa63e89000)
	libcairo.so.2 => /lib/x86_64-linux-gnu/libcairo.so.2 (0x00007faa63ab7000)
	libvulkan.so.1 => /lib/x86_64-linux-gnu/libvulkan.so.1 (0x00007faa62f82000)
	libgraphene-1.0.so.0 => /lib/x86_64-linux-gnu/libgraphene-1.0.so.0 (0x00007faa63e6c000)
	libgio-2.0.so.0 => /lib/x86_64-linux-gnu/libgio-2.0.so.0 (0x00007faa62d8d000)
	libgobject-2.0.so.0 => /lib/x86_64-linux-gnu/libgobject-2.0.so.0 (0x00007faa62d2a000)
	libglib-2.0.so.0 => /lib/x86_64-linux-gnu/libglib-2.0.so.0 (0x00007faa62bdb000)
	libgtk4-layer-shell.so.0 => /lib/x86_64-linux-gnu/libgtk4-layer-shell.so.0 (0x00007faa63e61000)
	libstdc++.so.6 => /lib/x86_64-linux-gnu/libstdc++.so.6 (0x00007faa62800000)
	libm.so.6 => /lib/x86_64-linux-gnu/libm.so.6 (0x00007faa62af5000)
	libgcc_s.so.1 => /lib/x86_64-linux-gnu/libgcc_s.so.1 (0x00007faa63a8a000)
	libc.so.6 => /lib/x86_64-linux-gnu/libc.so.6 (0x00007faa6260a000)
	libgmodule-2.0.so.0 => /lib/x86_64-linux-gnu/libgmodule-2.0.so.0 (0x00007faa63e5a000)
	/lib64/ld-linux-x86-64.so.2 (0x00007faa646be000)
	libharfbuzz-subset.so.0 => /lib/x86_64-linux-gnu/libharfbuzz-subset.so.0 (0x00007faa6249e000)
	libfribidi.so.0 => /lib/x86_64-linux-gnu/libfribidi.so.0 (0x00007faa62ad6000)
	libfontconfig.so.1 => /lib/x86_64-linux-gnu/libfontconfig.so.1 (0x00007faa62a88000)
	libepoxy.so.0 => /lib/x86_64-linux-gnu/libepoxy.so.0 (0x00007faa6236e000)
	libXi.so.6 => /lib/x86_64-linux-gnu/libXi.so.6 (0x00007faa63e44000)
	libX11.so.6 => /lib/x86_64-linux-gnu/libX11.so.6 (0x00007faa62226000)
	libpangoft2-1.0.so.0 => /lib/x86_64-linux-gnu/libpangoft2-1.0.so.0 (0x00007faa62a6b000)
	libcloudproviders.so.0 => /lib/x86_64-linux-gnu/libcloudproviders.so.0 (0x00007faa6220e000)
	libpng16.so.16 => /lib/x86_64-linux-gnu/libpng16.so.16 (0x00007faa621d6000)
	libtiff.so.6 => /lib/x86_64-linux-gnu/libtiff.so.6 (0x00007faa62147000)
	libjpeg.so.62 => /lib/x86_64-linux-gnu/libjpeg.so.62 (0x00007faa620b0000)
	libxkbcommon.so.0 => /lib/x86_64-linux-gnu/libxkbcommon.so.0 (0x00007faa62065000)
	libwayland-client.so.0 => /lib/x86_64-linux-gnu/libwayland-client.so.0 (0x00007faa62052000)
	libwayland-egl.so.1 => /lib/x86_64-linux-gnu/libwayland-egl.so.1 (0x00007faa63a85000)
	libXext.so.6 => /lib/x86_64-linux-gnu/libXext.so.6 (0x00007faa6203d000)
	libXcursor.so.1 => /lib/x86_64-linux-gnu/libXcursor.so.1 (0x00007faa62030000)
	libXdamage.so.1 => /lib/x86_64-linux-gnu/libXdamage.so.1 (0x00007faa62a66000)
	libXfixes.so.3 => /lib/x86_64-linux-gnu/libXfixes.so.3 (0x00007faa62028000)
	libXrandr.so.2 => /lib/x86_64-linux-gnu/libXrandr.so.2 (0x00007faa6201b000)
	libXinerama.so.1 => /lib/x86_64-linux-gnu/libXinerama.so.1 (0x00007faa62016000)
	libcairo-script-interpreter.so.2 => /lib/x86_64-linux-gnu/libcairo-script-interpreter.so.2 (0x00007faa61fef000)
	libthai.so.0 => /lib/x86_64-linux-gnu/libthai.so.0 (0x00007faa61fe2000)
	libfreetype.so.6 => /lib/x86_64-linux-gnu/libfreetype.so.6 (0x00007faa61f12000)
	libgraphite2.so.3 => /lib/x86_64-linux-gnu/libgraphite2.so.3 (0x00007faa61ee8000)
	libz.so.1 => /lib/x86_64-linux-gnu/libz.so.1 (0x00007faa61ec8000)
	libXrender.so.1 => /lib/x86_64-linux-gnu/libXrender.so.1 (0x00007faa61ebb000)
	libxcb.so.1 => /lib/x86_64-linux-gnu/libxcb.so.1 (0x00007faa61e8e000)
	libxcb-render.so.0 => /lib/x86_64-linux-gnu/libxcb-render.so.0 (0x00007faa61e7f000)
	libxcb-shm.so.0 => /lib/x86_64-linux-gnu/libxcb-shm.so.0 (0x00007faa61e7a000)
	libpixman-1.so.0 => /lib/x86_64-linux-gnu/libpixman-1.so.0 (0x00007faa61dcd000)
	libmount.so.1 => /lib/x86_64-linux-gnu/libmount.so.1 (0x00007faa61d58000)
	libselinux.so.1 => /lib/x86_64-linux-gnu/libselinux.so.1 (0x00007faa61d26000)
	libffi.so.8 => /lib/x86_64-linux-gnu/libffi.so.8 (0x00007faa61d19000)
	libatomic.so.1 => /lib/x86_64-linux-gnu/libatomic.so.1 (0x00007faa61d0f000)
	libpcre2-8.so.0 => /lib/x86_64-linux-gnu/libpcre2-8.so.0 (0x00007faa61c6d000)
	libexpat.so.1 => /lib/x86_64-linux-gnu/libexpat.so.1 (0x00007faa61c42000)
	libwebp.so.7 => /lib/x86_64-linux-gnu/libwebp.so.7 (0x00007faa61bbf000)
	libzstd.so.1 => /lib/x86_64-linux-gnu/libzstd.so.1 (0x00007faa61af7000)
	liblzma.so.5 => /lib/x86_64-linux-gnu/liblzma.so.5 (0x00007faa61ac6000)
	libLerc.so.4 => /lib/x86_64-linux-gnu/libLerc.so.4 (0x00007faa61a38000)
	libjbig.so.0 => /lib/x86_64-linux-gnu/libjbig.so.0 (0x00007faa61a27000)
	libdeflate.so.0 => /lib/x86_64-linux-gnu/libdeflate.so.0 (0x00007faa61a0e000)
	liblzo2.so.2 => /lib/x86_64-linux-gnu/liblzo2.so.2 (0x00007faa619ea000)
	libdatrie.so.1 => /lib/x86_64-linux-gnu/libdatrie.so.1 (0x00007faa619e0000)
	libbz2.so.1.0 => /lib/x86_64-linux-gnu/libbz2.so.1.0 (0x00007faa619cd000)
	libbrotlidec.so.1 => /lib/x86_64-linux-gnu/libbrotlidec.so.1 (0x00007faa619bf000)
	libXau.so.6 => /lib/x86_64-linux-gnu/libXau.so.6 (0x00007faa619b8000)
	libXdmcp.so.6 => /lib/x86_64-linux-gnu/libXdmcp.so.6 (0x00007faa619b0000)
	libblkid.so.1 => /lib/x86_64-linux-gnu/libblkid.so.1 (0x00007faa61951000)
	libsharpyuv.so.0 => /lib/x86_64-linux-gnu/libsharpyuv.so.0 (0x00007faa61948000)
	libbrotlicommon.so.1 => /lib/x86_64-linux-gnu/libbrotlicommon.so.1 (0x00007faa61925000)
```

</p>
</details> 

Fixes https://github.com/System64fumo/syshud/issues/21.