### PR TITLE
Correct the List of Listeners in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ arguments:
   -t	Set timeout
   -T	Set transition time (0 disables animations)
   -b	Set custom backlight path
-  -M	Set things to monitor (audio_in, audio_out, brightness, keyboard)
+  -M	Set things to monitor (audio_in, audio_out, backlight, keyboard)
   -k	Set keyboard path (/dev/input/by-id/my_keyboard-event-kbd)
   -v	Prints version info
 ```


### PR DESCRIPTION
The listener `backlight` is incorrectly listed as `brightness` in the README.